### PR TITLE
Collections list from Solr as JSON

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var DEFAULT_OPTIONS = {
     zkConnectionString: 'localhost:2181',
     zkLiveNodes: '/live_nodes',
     solrProtocol: 'http',
-    solrCollectionsGetEndPoint: '/admin/collections?action=LIST',
+    solrCollectionsGetEndPoint: '/admin/collections?action=LIST&wt=json',
     ssh: {},
     // Passed verbatim to node-zookeeper-client
     zk: {
@@ -66,9 +66,7 @@ function getSolrParams(solrInstance, options, callback) {
 
 function getSolrInstance(solrBundles, solrCollection, callback) {
     async.filter(solrBundles, function (bundle, callback) {
-        async.some(bundle.collections, function (collection, callback) {
-            callback(collection == solrCollection);
-        }, callback)
+        callback(bundle.collections == solrCollection);
     }, function (filteredBundles) {
         async.map(filteredBundles, function (bundle, callback) {
             callback(null, bundle.instance);
@@ -95,9 +93,10 @@ function getSolrCollections(solrInstances, options, callback) {
         var protocolInstance = options.solrProtocol + '://' + instance;
         return function (callback) {
             client.get(protocolInstance + options.solrCollectionsGetEndPoint, options.rest, function (data /*, response*/) {
+                data = JSON.parse(data);
                 var bundle = {
                     instance: protocolInstance,
-                    collections: data.response.arr[0].str
+                    collections: data.collections[0]
                 };
                 callback(null, bundle);
             });

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var DEFAULT_OPTIONS = {
     zkConnectionString: 'localhost:2181',
     zkLiveNodes: '/live_nodes',
     solrProtocol: 'http',
-    solrCollectionsGetEndPoint: '/admin/collections?action=LIST&wt=json',
+    solrCollectionsGetEndPoint: '/admin/collections?action=LIST',
     ssh: {},
     // Passed verbatim to node-zookeeper-client
     zk: {
@@ -66,7 +66,9 @@ function getSolrParams(solrInstance, options, callback) {
 
 function getSolrInstance(solrBundles, solrCollection, callback) {
     async.filter(solrBundles, function (bundle, callback) {
-        callback(bundle.collections == solrCollection);
+        async.some(bundle.collections, function (collection, callback) {
+            callback(collection == solrCollection);
+        }, callback)
     }, function (filteredBundles) {
         async.map(filteredBundles, function (bundle, callback) {
             callback(null, bundle.instance);
@@ -93,10 +95,16 @@ function getSolrCollections(solrInstances, options, callback) {
         var protocolInstance = options.solrProtocol + '://' + instance;
         return function (callback) {
             client.get(protocolInstance + options.solrCollectionsGetEndPoint, options.rest, function (data /*, response*/) {
-                data = JSON.parse(data);
+                var instanceCollections;
+                if(-1 !== options.solrCollectionsGetEndPoint.indexOf('wt=json'))
+                {
+                    instanceCollections = JSON.parse(data).collections;
+                }else{
+                    instanceCollections = data.response.arr[0].str;
+                }
                 var bundle = {
                     instance: protocolInstance,
-                    collections: data.collections[0]
+                    collections: instanceCollections,
                 };
                 callback(null, bundle);
             });


### PR DESCRIPTION
I'm using Solr 5.0 and ZooKeeper 3.4.6 and had problem with detecting collections.
I repeatedly got:
Found no Solr instance hosting collection testCollection

And I was sure that collection exists. So I debugged it a little and found out that variable data in getSolrCollections() is XML. So I did a little tweak and now if someone adds '&wt=json' to solrCollectionsGetEndPoint data is JSON and bundle can be created.
From here on everything works great.

Thanks.
