### PR TITLE
Added event handlers for rest requests for solr collections list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ function createSolrCollectionGETRequestTasks(zkInfo, options) {
         }
         var protocolLiveNode = options.solrProtocol + '://' + liveNode;
         return function (callback) {
-            restClient.get(protocolLiveNode + options.solrCollectionsGetEndPoint, options.rest, function (data, response) {
+            var req = restClient.get(protocolLiveNode + options.solrCollectionsGetEndPoint, options.rest, function (data, response) {
                 var instanceCollections;
                 if (isXMLRESTResponse(response)) {
                     instanceCollections = data.response.arr[0].str;
@@ -110,6 +110,16 @@ function createSolrCollectionGETRequestTasks(zkInfo, options) {
                     collections: instanceCollections
                 };
                 callback(null, bundle);
+            });
+            req.on("requestTimeout", function(req) {
+                req.abort();
+                callback("Request timed out", req);
+            });
+            req.on("responseTimeout", function(res) {
+                callback("Response timed out", res);
+            });
+            req.on("error", function(err) {
+                callback(err);
             });
         };
     });


### PR DESCRIPTION
I've added these event handlers because our node process is exiting when we scale in solr replica nodes and these requests get made to a replica node that is down.